### PR TITLE
fix randomness call to freedom core.crypto

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -19,7 +19,7 @@ exports.refreshBuffer = function (size, callback) {
     return;
   }
 
-  fcrypto.getRandomvalues(size).then(function (b) {
+  fcrypto.getRandomBytes(size).then(function (b) {
     buf = new Uint8Array(b);
     offset = 0;
     callback(0);


### PR DESCRIPTION
Courtesy of @dborkan, this fix is needed due to errors in Firefox webworkers with uProxy. Thanks!
