### PR TITLE
doubling buffer size

### DIFF
--- a/src/metric.js
+++ b/src/metric.js
@@ -20,8 +20,8 @@ var getRandomness = function (callback) {
     }
   }
   return new Promise(function (resolve) {
-    console.log('asking to reload to ', 4*bloombits);
-    crypt.refreshBuffer(4 * 8 * bloombits + Object.keys(definitions).length, resolve);
+    console.log('asking to reload to ', 8*bloombits);
+    crypt.refreshBuffer(8 * 8 * bloombits + Object.keys(definitions).length, resolve);
   });
 };
 


### PR DESCRIPTION
This doubles the buffer size relative to the bloom bits - @dborkan is trying to enable Firefox metrics in uProxy (https://github.com/uproxy/uproxy/tree/dborkan-firefox-metrics) and was encountering "insufficient randomness" error messages. This change fixes that - just increasing the # of bloombits as a parameter seems to both increase the buffer size and the rate at which it is consumed.

Let me know if this fix feels appropriate or not - thanks!
