### PR TITLE
Put built files in a dist directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
+dist/
+
 # Dependency directory
 # Commenting this out is preferred by some people, see
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,7 +7,7 @@ module.exports = function (grunt) {
     browserify: {
       metrics: {
         files: {
-          'metric.js': ['src/metric.js']
+          'dist/metric.js': ['src/metric.js']
         }
       },
       options: {
@@ -17,6 +17,12 @@ module.exports = function (grunt) {
         require: ['./src/crypto:crypto']
       }
     },
+    copy: {
+      dist: {
+        src: 'anonmetrics.json',
+        dest: 'dist/'
+      }
+    },
     jshint: {
       all: ['src/*.js']
     }
@@ -24,8 +30,9 @@ module.exports = function (grunt) {
 
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-browserify');
+  grunt.loadNpmTasks('grunt-contrib-copy');
 
-  grunt.registerTask('build', ['browserify']);
+  grunt.registerTask('build', ['browserify', 'copy:dist']);
   grunt.registerTask('test', ['jshint']);
   grunt.registerTask('default', ['build', 'test']);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freedomjs-anonymized-metrics",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Privacy Preserving metrics reporting, using the rappor algorithm",
   "main": "metric.js",
   "scripts": {
@@ -20,6 +20,7 @@
     "freedom": "^0.6.24",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.7.0",
+    "grunt-contrib-copy": "^0.8.2",
     "grunt-contrib-jshint": "^0.11.1",
     "rappor": "^1.0.0"
   }


### PR DESCRIPTION
An attempt to keep things standardized between the various npm packages used in uproxy (this is the only freedom module we seem to be using that does not place code in a dist directory)
